### PR TITLE
Add shebang to all scripts

### DIFF
--- a/getcias.sh
+++ b/getcias.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 TAG_CP="v3.7.4" # has to be constant due to latest having no 3ds release
 
 mkdir cias

--- a/preparezip.sh
+++ b/preparezip.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 source ./getcias.sh
 
 # constants because gm9 is suck(if someone maintains this, update it ^^)


### PR DESCRIPTION
Without this, some Linux operating systems are causing `Exec format error`.

It is generally considered common practice to add the shebang line to any shell script to be able to directly run it via `./script.sh`.